### PR TITLE
Use magrittr pipe instead of base pipe for consistency.

### DIFF
--- a/R/class_confusion_matrix.R
+++ b/R/class_confusion_matrix.R
@@ -86,7 +86,7 @@ confusion_matrix <- function(data = NULL, obs, pred,
         dplyr::mutate(PREDICTED = as.factor(PREDICTED), OBSERVED = as.factor(OBSERVED)) %>% 
         dplyr::rename(count = Freq) %>%
         dplyr::mutate(proportion = round(count/sum(count),2) ) %>% 
-        dplyr::mutate(isdiag = (PREDICTED == OBSERVED)) |>
+        dplyr::mutate(isdiag = (PREDICTED == OBSERVED)) %>%
         dplyr::arrange(isdiag)
       # Obtain the levels the order the cm
       levels <- levels(mat_plot[["PREDICTED"]])


### PR DESCRIPTION
`class_confusion_matrix.R` uses the new base pipe in one instance in what seems like a typo. With the base pipe use the advertised minimum R version (`2.10`) is not true anymore.

Noticed during packaging for conda-forge.